### PR TITLE
Add Farcaster MiniApp manifest and Farcaster-first auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/lndy-favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="alternate" type="application/json" href="/farcaster.json" title="LNDY Farcaster MiniApp Manifest" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="LNDY - Social lending powered by Ethereum. Create and fund loans using blockchain technology." />
+    <meta name="fc:miniapp:manifest" content="/farcaster.json" />
+    <meta name="fc:frame" content="vNext" />
     <title>LNDY</title>
   </head>
   <body>

--- a/public/farcaster.json
+++ b/public/farcaster.json
@@ -1,0 +1,16 @@
+{
+  "name": "LNDY",
+  "description": "Social lending on Base. Create and fund crypto-native loans with people you trust.",
+  "icon": "/lndy-favicon.svg",
+  "splash_image": "/lndy-favicon.svg",
+  "splash_color": "#111827",
+  "theme": {
+    "primary": "#4f46e5",
+    "secondary": "#06b6d4",
+    "background": "#111827"
+  },
+  "web_app": {
+    "manifest": "/manifest.webmanifest",
+    "mobile_optimized": true
+  }
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "LNDY",
+  "short_name": "LNDY",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#4f46e5",
+  "icons": [
+    {
+      "src": "/lndy-favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { ThirdwebProvider, ConnectButton } from "thirdweb/react";
-import { createThirdwebClient } from "thirdweb";
+import { ThirdwebProvider, ConnectButton, useActiveWallet, useConnectModal } from "thirdweb/react";
+import { createThirdwebClient, type ThirdwebClient } from "thirdweb";
 import { base } from "thirdweb/chains";
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createWallet, inAppWallet } from "thirdweb/wallets";
 import "./App.css";
 
 import CreateLoan from "./components/CreateLoan";
@@ -9,10 +10,216 @@ import LoanList from "./components/LoanList";
 import Dashboard from "./components/Dashboard";
 import MyLoans from "./pages/MyLoans";
 import About from "./components/About";
+import { useIsFarcasterPreferred } from "./hooks/useIsFarcasterPreferred";
+
+type AppShellProps = {
+  client: ThirdwebClient;
+};
+
+const AppShell = ({ client }: AppShellProps) => {
+  const [activeTab, setActiveTab] = useState<"browse" | "create" | "myloans" | "dashboard" | "about">("browse");
+  const activeWallet = useActiveWallet();
+  const { connect, isConnecting } = useConnectModal();
+  const isFarcasterPreferred = useIsFarcasterPreferred();
+  const hasPromptedRef = useRef(false);
+
+  const wallets = useMemo(
+    () => [
+      inAppWallet({
+        auth: {
+          options: ["farcaster", "email", "google", "passkey", "guest"],
+        },
+        metadata: {
+          name: "LNDY",
+          icon: "/lndy-favicon.svg",
+        },
+      }),
+      createWallet("io.metamask"),
+      createWallet("com.coinbase.wallet"),
+      createWallet("me.rainbow"),
+    ],
+    [],
+  );
+
+  useEffect(() => {
+    if (!isFarcasterPreferred || activeWallet || isConnecting || hasPromptedRef.current) {
+      return;
+    }
+
+    hasPromptedRef.current = true;
+
+    void connect({
+      client,
+      chain: base,
+      wallets,
+      size: "compact",
+      title: "Sign in to LNDY",
+      titleIcon: "/lndy-favicon.svg",
+      showThirdwebBranding: false,
+      welcomeScreen: {
+        title: "Log in with Farcaster",
+        subtitle: "Use your Farcaster identity to access the LNDY MiniApp.",
+      },
+    }).catch((error) => {
+      console.debug("Farcaster auto-connect dismissed", error);
+    });
+  }, [
+    isFarcasterPreferred,
+    activeWallet,
+    isConnecting,
+    connect,
+    client,
+    wallets,
+  ]);
+
+  return (
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 shadow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">LNDY</h1>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">Social lending powered by Ethereum</p>
+            </div>
+            <div className="flex flex-col items-stretch sm:items-end gap-2">
+              <ConnectButton
+                client={client}
+                chain={base}
+                wallets={wallets}
+                connectButton={{
+                  label:
+                    activeWallet || isConnecting
+                      ? undefined
+                      : isFarcasterPreferred
+                        ? "Sign in with Farcaster"
+                        : "Connect Wallet",
+                }}
+                connectModal={{
+                  size: "compact",
+                  title: "Sign in to LNDY",
+                  titleIcon: "/lndy-favicon.svg",
+                  showThirdwebBranding: false,
+                }}
+              />
+              {isFarcasterPreferred && !activeWallet && (
+                <p className="text-xs text-indigo-600 dark:text-indigo-300 text-right">
+                  Tip: you can authenticate instantly with your Farcaster account.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <nav className="bg-white dark:bg-gray-800 shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-wrap gap-4 sm:gap-8 py-3 sm:py-0">
+            <button
+              className={`px-3 py-2 sm:py-4 text-sm font-medium ${
+                activeTab === "browse"
+                  ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+              }`}
+              onClick={() => setActiveTab("browse")}
+            >
+              Browse Loans
+            </button>
+            <button
+              className={`px-3 py-2 sm:py-4 text-sm font-medium ${
+                activeTab === "create"
+                  ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+              }`}
+              onClick={() => setActiveTab("create")}
+            >
+              Create Loan
+            </button>
+            <button
+              className={`px-3 py-2 sm:py-4 text-sm font-medium ${
+                activeTab === "myloans"
+                  ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+              }`}
+              onClick={() => setActiveTab("myloans")}
+            >
+              My Loans
+            </button>
+            <button
+              className={`px-3 py-2 sm:py-4 text-sm font-medium ${
+                activeTab === "dashboard"
+                  ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+              }`}
+              onClick={() => setActiveTab("dashboard")}
+            >
+              My Dashboard
+            </button>
+            <button
+              className={`px-3 py-2 sm:py-4 text-sm font-medium ${
+                activeTab === "about"
+                  ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+              }`}
+              onClick={() => setActiveTab("about")}
+            >
+              About
+            </button>
+          </div>
+        </div>
+      </nav>
+
+      {/* Alpha Warning Banner */}
+      <div className="bg-red-50 dark:bg-red-900/20 border-l-4 border-red-400 dark:border-red-600">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fillRule="evenodd"
+                  d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+            <div className="ml-3">
+              <div className="text-sm text-red-800 dark:text-red-200">
+                <p className="font-medium">⚠️ ALPHA SOFTWARE WARNING</p>
+                <p className="mt-1">
+                  This is experimental software in early development. <strong>Only invest money you can afford to lose completely.</strong>
+                  Only fund loans from people you know personally and trust. Borrowers may be unable or unwilling to repay for various reasons including financial hardship, technical issues, or fraud.
+                  Smart contracts may contain bugs. Use at your own risk.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {activeTab === "browse" && <LoanList />}
+        {activeTab === "create" && <CreateLoan />}
+        {activeTab === "myloans" && <MyLoans />}
+        {activeTab === "dashboard" && <Dashboard />}
+        {activeTab === "about" && <About />}
+      </main>
+
+      <footer className="bg-white dark:bg-gray-800 shadow-inner mt-auto">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="text-center space-y-2">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              LNDY - Social Lending Platform © {new Date().getFullYear()}
+            </p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              Alpha software. High risk. Only lend to people you know personally. Not financial advice.
+            </p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
 
 function App() {
-  const [activeTab, setActiveTab] = useState<"browse" | "create" | "myloans" | "dashboard" | "about">("browse");
-
   // Check if required environment variables are set
   const clientId = import.meta.env.VITE_THIRDWEB_CLIENT_ID;
 
@@ -38,121 +245,7 @@ function App() {
 
   return (
     <ThirdwebProvider>
-      <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
-        <header className="bg-white dark:bg-gray-800 shadow">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            <div className="flex justify-between items-center">
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">LNDY</h1>
-              <ConnectButton 
-                client={client}
-                chain={base}
-              />
-            </div>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">Social lending powered by Ethereum</p>
-          </div>
-        </header>
-
-        <nav className="bg-white dark:bg-gray-800 shadow-sm">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex space-x-8">
-              <button
-                className={`px-3 py-4 text-sm font-medium ${
-                  activeTab === "browse"
-                    ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
-                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                }`}
-                onClick={() => setActiveTab("browse")}
-              >
-                Browse Loans
-              </button>
-              <button
-                className={`px-3 py-4 text-sm font-medium ${
-                  activeTab === "create"
-                    ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
-                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                }`}
-                onClick={() => setActiveTab("create")}
-              >
-                Create Loan
-              </button>
-              <button
-                className={`px-3 py-4 text-sm font-medium ${
-                  activeTab === "myloans"
-                    ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
-                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                }`}
-                onClick={() => setActiveTab("myloans")}
-              >
-                My Loans
-              </button>
-              <button
-                className={`px-3 py-4 text-sm font-medium ${
-                  activeTab === "dashboard"
-                    ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
-                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                }`}
-                onClick={() => setActiveTab("dashboard")}
-              >
-                My Dashboard
-              </button>
-              <button
-                className={`px-3 py-4 text-sm font-medium ${
-                  activeTab === "about"
-                    ? "text-indigo-600 dark:text-indigo-400 border-b-2 border-indigo-600 dark:border-indigo-400"
-                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                }`}
-                onClick={() => setActiveTab("about")}
-              >
-                About
-              </button>
-            </div>
-          </div>
-        </nav>
-
-        {/* Alpha Warning Banner */}
-        <div className="bg-red-50 dark:bg-red-900/20 border-l-4 border-red-400 dark:border-red-600">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-            <div className="flex">
-              <div className="flex-shrink-0">
-                <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-                </svg>
-              </div>
-              <div className="ml-3">
-                <div className="text-sm text-red-800 dark:text-red-200">
-                  <p className="font-medium">⚠️ ALPHA SOFTWARE WARNING</p>
-                  <p className="mt-1">
-                    This is experimental software in early development. <strong>Only invest money you can afford to lose completely.</strong> 
-                    Only fund loans from people you know personally and trust. Borrowers may be unable or unwilling to repay for various reasons including financial hardship, technical issues, or fraud. 
-                    Smart contracts may contain bugs. Use at your own risk.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          {activeTab === "browse" && <LoanList />}
-          {activeTab === "create" && <CreateLoan />}
-          {activeTab === "myloans" && <MyLoans />}
-          {activeTab === "dashboard" && <Dashboard />}
-          {activeTab === "about" && <About />}
-        </main>
-
-        <footer className="bg-white dark:bg-gray-800 shadow-inner mt-auto">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            <div className="text-center space-y-2">
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                LNDY - Social Lending Platform © {new Date().getFullYear()}
-              </p>
-              <p className="text-xs text-gray-400 dark:text-gray-500">
-                Alpha software. High risk. Only lend to people you know personally. Not financial advice.
-              </p>
-            </div>
-          </div>
-        </footer>
-      </div>
+      <AppShell client={client} />
     </ThirdwebProvider>
   );
 }

--- a/src/hooks/useIsFarcasterPreferred.ts
+++ b/src/hooks/useIsFarcasterPreferred.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+type FarcasterWindow = Window & {
+  farcaster?: {
+    miniApp?: unknown;
+    signer?: unknown;
+    user?: unknown;
+  };
+  FarcasterMiniApp?: unknown;
+};
+
+/**
+ * Detect whether the current environment looks like it is being opened from a Farcaster client.
+ * This covers Warpcast MiniApps as well as regular browsers that expose the `window.farcaster` bridge.
+ */
+export const useIsFarcasterPreferred = () => {
+  const [isPreferred, setIsPreferred] = useState(false);
+
+  useEffect(() => {
+    const win = window as FarcasterWindow;
+    const userAgent = win.navigator?.userAgent?.toLowerCase() ?? "";
+    const searchParams = new URLSearchParams(win.location?.search ?? "");
+
+    const hasBridge = Boolean(win.farcaster);
+    const isMiniApp = Boolean(win.farcaster?.miniApp || win.FarcasterMiniApp);
+    const fromQuery = ["source", "utm_source", "farcaster"].some((param) => {
+      const value = searchParams.get(param);
+      if (!value) return false;
+      return value.toLowerCase().includes("farcaster") || value === "1";
+    });
+    const agentHints = ["warpcast", "farcaster", "dwrfc"].some((hint) =>
+      userAgent.includes(hint),
+    );
+
+    setIsPreferred(hasBridge || isMiniApp || fromQuery || agentHints);
+  }, []);
+
+  return isPreferred;
+};


### PR DESCRIPTION
## Summary
- add Farcaster MiniApp and PWA manifests and expose them via the HTML head for Farcaster clients
- update the Thirdweb connect flow to prioritize Farcaster auth, auto-open in MiniApps, and refine header layout for small viewports
- add a Farcaster environment detection hook to drive the login experience

## Testing
- npm run build -- --logLevel error

------
https://chatgpt.com/codex/tasks/task_e_68dc87d977708323aaffb7de01a7ce0f