### PR TITLE
Fix Farcaster wallet detection across the app

### DIFF
--- a/src/context/FarcasterWalletContext.tsx
+++ b/src/context/FarcasterWalletContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { useFarcasterWallet } from "../hooks/useFarcasterWallet";
+
+type FarcasterWalletContextValue = ReturnType<typeof useFarcasterWallet>;
+
+const FarcasterWalletContext = createContext<FarcasterWalletContextValue | null>(null);
+
+interface FarcasterWalletProviderProps {
+  children: ReactNode;
+}
+
+export const FarcasterWalletProvider = ({ children }: FarcasterWalletProviderProps) => {
+  const farcasterWallet = useFarcasterWallet();
+
+  return (
+    <FarcasterWalletContext.Provider value={farcasterWallet}>
+      {children}
+    </FarcasterWalletContext.Provider>
+  );
+};
+
+export const useFarcasterWalletContext = () => useContext(FarcasterWalletContext);

--- a/src/hooks/useIsFarcasterPreferred.ts
+++ b/src/hooks/useIsFarcasterPreferred.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { sdk } from "@farcaster/miniapp-sdk";
 
 type FarcasterWindow = Window & {
   farcaster?: {
@@ -32,7 +33,25 @@ export const useIsFarcasterPreferred = () => {
       userAgent.includes(hint),
     );
 
-    setIsPreferred(hasBridge || isMiniApp || fromQuery || agentHints);
+    const immediatePreference = hasBridge || isMiniApp || fromQuery || agentHints;
+    setIsPreferred(immediatePreference);
+
+    let isMounted = true;
+
+    sdk
+      .isInMiniApp()
+      .then((result) => {
+        if (isMounted && result) {
+          setIsPreferred(true);
+        }
+      })
+      .catch((error) => {
+        console.debug("useIsFarcasterPreferred: sdk.isInMiniApp error", error);
+      });
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   return isPreferred;

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,5 +1,5 @@
 import { useActiveWallet } from "thirdweb/react";
-import { useFarcasterWallet } from "./useFarcasterWallet";
+import { useFarcasterWalletContext } from "../context/FarcasterWalletContext";
 
 /**
  * Unified wallet hook that provides the active wallet from either
@@ -7,7 +7,9 @@ import { useFarcasterWallet } from "./useFarcasterWallet";
  */
 export const useWallet = () => {
   const activeWallet = useActiveWallet();
-  const { wallet: farcasterWallet, isConnected: isFarcasterConnected } = useFarcasterWallet();
+  const farcasterContext = useFarcasterWalletContext();
+  const farcasterWallet = farcasterContext?.wallet ?? null;
+  const isFarcasterConnected = farcasterContext?.isConnected ?? false;
 
   // Prioritize Farcaster embedded wallet if available
   if (isFarcasterConnected && farcasterWallet) {


### PR DESCRIPTION
## Summary
- add a Farcaster wallet context provider so embedded wallet state is shared across components
- update the app shell to consume the shared Farcaster state and guard the connect button logic
- switch the unified wallet hook to read from the context so Farcaster connections register correctly
- detect Farcaster MiniApp environments via the SDK so Warpcast web sessions initialize the embedded wallet and disable it elsewhere

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68def3a466d483238af29800460e293d