### PR TITLE
Fix missing useMemo imports in loan modals

### DIFF
--- a/src/components/FundingModal.tsx
+++ b/src/components/FundingModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useWallet } from "../hooks/useWallet";
 import { prepareContractCall, getContract, readContract } from "thirdweb";
 import { getLoanContract } from "../lib/client";

--- a/src/components/RepaymentModal.tsx
+++ b/src/components/RepaymentModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useWallet } from "../hooks/useWallet";
 import { prepareContractCall, getContract, readContract } from "thirdweb";
 import { getLoanContract } from "../lib/client";


### PR DESCRIPTION
## Summary
- import `useMemo` in the funding modal so the hook is available at runtime
- import `useMemo` in the repayment modal for the same reason

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1132fca88323a3004b1234808160