### PR TITLE
fix: use png assets for miniapp preview

### DIFF
--- a/public/farcaster.json
+++ b/public/farcaster.json
@@ -7,20 +7,20 @@
   "miniApp": {
     "version": "1",
     "name": "LNDY - Social Lending",
-    "iconUrl": "https://lndy.org/lndy-favicon.svg",
+    "iconUrl": "https://lndy.org/miniapp-tile.png",
     "homeUrl": "https://lndy.org",
-    "imageUrl": "https://lndy.org/lndy-favicon.svg",
+    "imageUrl": "https://lndy.org/miniapp-tile.png",
     "button": {
       "title": "Browse Loans",
       "action": {
         "type": "launch_miniapp",
         "name": "LNDY - Social Lending",
         "url": "https://lndy.org",
-        "splashImageUrl": "https://lndy.org/lndy-favicon.svg",
+        "splashImageUrl": "https://lndy.org/miniapp-tile.png",
         "splashBackgroundColor": "#111827"
       }
     },
-    "splashImageUrl": "https://lndy.org/lndy-favicon.svg",
+    "splashImageUrl": "https://lndy.org/miniapp-tile.png",
     "splashBackgroundColor": "#111827",
     "webhookUrl": "https://lndy.org/api/webhook"
   }


### PR DESCRIPTION
## Summary
- switch Farcaster miniapp metadata to use the PNG tile asset instead of the SVG favicon
- ensure the preview, icon, and splash references point to the supported image format

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df25399c3c83238bb22e0e716a36c7