### PR TITLE
fix: decode react production errors automatically

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { decodeReactError, type DecodedReactError } from "../utils/reactErrorDecoder";
 
 interface ErrorBoundaryState {
   hasError: boolean;
   error?: Error;
   errorInfo?: React.ErrorInfo;
+  decodedError?: DecodedReactError | null;
 }
 
 interface ErrorBoundaryProps {
@@ -13,20 +15,29 @@ interface ErrorBoundaryProps {
 class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, decodedError: null };
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { hasError: true, error };
+    return { hasError: true, error, decodedError: null };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('🚨 ErrorBoundary caught an error:', error, errorInfo);
     console.error('🚨 Full error stack:', error.stack);
     console.error('🚨 Component stack:', errorInfo.componentStack);
-    
+
+    const decodedError = decodeReactError(error);
+
+    if (decodedError) {
+      console.info('🧩 Decoded React error:', decodedError);
+    }
+
     // Store error info in state for display
-    this.setState({ errorInfo });
+    this.setState({
+      errorInfo,
+      decodedError,
+    });
   }
 
   render() {
@@ -54,6 +65,28 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
                     {this.state.error?.message || 'Unknown error'}
                   </code>
                 </div>
+                {this.state.decodedError && (
+                  <div className="mt-4 space-y-2">
+                    <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded p-3">
+                      <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                        React decoded message
+                      </p>
+                      <p className="mt-1 text-sm text-blue-800 dark:text-blue-200">
+                        {this.state.decodedError.message}
+                      </p>
+                    </div>
+                    {this.state.decodedError.helpUrl && (
+                      <a
+                        href={this.state.decodedError.helpUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-xs font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100"
+                      >
+                        View official React guidance →
+                      </a>
+                    )}
+                  </div>
+                )}
               </div>
 
               {/* Error Type */}

--- a/src/utils/reactErrorDecoder.ts
+++ b/src/utils/reactErrorDecoder.ts
@@ -1,0 +1,72 @@
+const ERROR_TEMPLATES: Record<string, (args: string[]) => string> = {
+  "31": (args) => {
+    const found = args[0] ?? "an unknown value";
+    return [
+      "Objects are not valid as a React child.",
+      `React received ${found}.`,
+      "This usually means that some component tried to render an object or element reference instead of primitive text or a valid JSX tree.",
+      "Check any render functions that return data from APIs or smart contracts and ensure they convert values to strings, numbers, or React nodes before rendering.",
+    ].join(" ");
+  },
+};
+
+export interface DecodedReactError {
+  code: string;
+  message: string;
+  helpUrl: string;
+  args: string[];
+}
+
+const REACT_ERROR_REGEX = /Minified React error #(\d+); visit (https?:\/\/[^\s]+) for the full message/;
+const ARG_REGEX = /args\[]=(?<arg>[^&#]+)/g;
+
+export const decodeReactError = (error: unknown): DecodedReactError | null => {
+  if (!error) {
+    return null;
+  }
+
+  const message = typeof error === "string" ? error : error instanceof Error ? error.message : String(error);
+  const match = message.match(REACT_ERROR_REGEX);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, code, helpUrl] = match;
+  const args: string[] = [];
+
+  if (helpUrl) {
+    try {
+      const url = new URL(helpUrl);
+      const matches = url.href.matchAll(ARG_REGEX);
+
+      for (const argMatch of matches) {
+        const value = argMatch.groups?.arg;
+        if (value) {
+          args.push(decodeURIComponent(value));
+        }
+      }
+    } catch (parseError) {
+      console.warn("Failed to parse React error decoder URL:", parseError);
+    }
+  }
+
+  const template = ERROR_TEMPLATES[code];
+  const decodedMessage = template ? template(args) : null;
+
+  if (!decodedMessage) {
+    return {
+      code,
+      message: "React encountered a production-only error. Open the linked decoder URL for details.",
+      helpUrl,
+      args,
+    };
+  }
+
+  return {
+    code,
+    message: decodedMessage,
+    helpUrl,
+    args,
+  };
+};


### PR DESCRIPTION
## Summary
- add a utility that parses React's production-only error numbers into useful guidance
- surface the decoded message and docs link inside both root and nested error boundaries
- log decoded diagnostics in the console whenever the boundary catches a minified React error

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e08a16bac08323aafaae2e2856a073